### PR TITLE
Qr code: center the qr-code component

### DIFF
--- a/docs/qr-code/style.css
+++ b/docs/qr-code/style.css
@@ -26,10 +26,7 @@ body{
 }
 
 .qr-card{
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
+    max-width: max-content;
     background-color: hsl(var(--clr-white));
     border-radius: 1.2rem;
 }

--- a/docs/qr-code/style.css
+++ b/docs/qr-code/style.css
@@ -21,6 +21,9 @@ body{
 }
 
 .container{
+    display: flex;
+    align-items: center;
+    flex-direction: column;
     padding: 2rem;
     background-color: hsl(var(--clr-gray));
 }


### PR DESCRIPTION
- removed display from `.qr-code` class from style.css
- center everything